### PR TITLE
fix: multiple selected range labels

### DIFF
--- a/projects/ng-date-picker/src/lib/ng-date-picker.component.ts
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.component.ts
@@ -310,6 +310,8 @@ export class NgDatePickerComponent implements OnInit, AfterViewInit {
 
     let calculatedLabel = '';
 
+    this._dateDropDownOptions.forEach(dropDown => dropDown.isSelected = false);
+
     for (let i = 0; i < dateOptionsLength; i++) {
 
       if (this.labels && this._defaultOptionsInUse) {


### PR DESCRIPTION
Now the range labels ("Today", "This month" etc...) are unselected every time they are recomputed.